### PR TITLE
allow underscore to version number string

### DIFF
--- a/lib/serverspec/type/package.rb
+++ b/lib/serverspec/type/package.rb
@@ -25,7 +25,7 @@ module Serverspec::Type
       attr_reader :epoch, :version
 
       def initialize(val)
-        matches = val.match(/^(?:(\d+):)?(\d[0-9a-zA-Z.+:~-]*)$/)
+        matches = val.match(/^(?:(\d+):)?(\d[0-9a-zA-Z.+:~_-]*)$/)
         if matches.nil?
           raise ArgumentError, "Malformed version number string #{val}"
         end


### PR DESCRIPTION
Hi,

Some packages occured 'Malformed version number string' when retrieve version strings.
For example, The jre package provided by Sun Microsystems.

```
# rpm -qi jre
Name        : jre                          Relocations: /usr/java 
Version     : 1.6.0_13                          Vendor: Sun Microsystems, Inc.
Release     : fcs                           Build Date: Tue 10 Mar 2009 06:18:17 AM JST
Install Date: Wed 21 Jan 2015 10:15:26 AM JST      Build Host: jdk-lin-amd64.sfbay.sun.com
Group       : Development/Tools             Source RPM: jre-1.6.0_13-fcs.src.rpm
Size        : 47059709                         License: Sun Microsystems Binary Code License (BCL)
Signature   : (none)
Packager    : Java Software <jre-comments@java.sun.com>
URL         : http://java.sun.com/
Summary     : Java(TM) Platform Standard Edition Runtime Environment
Description :
```

I would like to include underscore to regexp.

```
## Before
> '1.6.0_13'.match(/^(?:(\d+):)?(\d[0-9a-zA-Z.+:~-]*)$/)
=> nil

## After
> '1.6.0_13'.match(/^(?:(\d+):)?(\d[0-9a-zA-Z.+:_~-]*)$/)
=> #<MatchData "1.6.0_13" 1:nil 2:"1.6.0_13">
```
