### PR TITLE
make vagrant-configured spec_helper work on windows

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -275,7 +275,8 @@ host = ENV['TARGET_HOST']
 `vagrant up #{host}`
 
 config = Tempfile.new('', Dir.tmpdir)
-`vagrant ssh-config #{host} > #{config.path}`
+config.write(`vagrant ssh-config #{host}`)
+config.close
 
 options = Net::SSH::Config.for(host, [config.path])
 <%- else -%>


### PR DESCRIPTION
The default "vagrant auto-configured" spec_helper does not work when run from a Windows host in ruby 1.9.3 or 2.0.0.

It looks like ruby was keeping a lock on the `config` tempfile so the system call to `vagrant ssh-config` couldn't pipe out to it. Or the system call was keeping a handle on it too long for Net::SSH to read the output back in again. It was unclear. Either way, running `rake spec` gave me:

```powershell
C:\src\serverspec> rake spec
c:/Ruby193/bin/ruby.exe -I'c:/Ruby193/lib/ruby/gems/1.9.1/gems/rspec-core-3.1.7/lib' c:/Ruby193/lib/ruby/gems/1.9.1/gems/rspec-core-3.1.7/exe/rspec --pattern 'spec/serverspec/*_spec.rb'
The process cannot access the file because it is being used by another process.
c:/Ruby193/lib/ruby/gems/1.9.1/gems/net-ssh-2.9.2/lib/net/ssh/transport/session.rb:70:in `initialize': getaddrinfo: No such host is known.  (SocketError)
```

And when I looked at `options`, nothing had been populated from the config file.

Writing out to it directly from the Ruby and ensuring we've finished with and closed the file before trying to read back in from it seems to do the trick and works cross-platform.