### PR TITLE
Fix 'uninitialized constant' error

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require 'fileutils'
 require 'erb'
 


### PR DESCRIPTION
Uninitialized constant error came out in the following operation.
`require "pathname"` it did not appear to have enough, we've added.

```
$ serverspec-init
DL is deprecated, please use Fiddle
Select OS type:

  1) UN*X
  2) Windows

Select number: 1

Select a backend type:

  1) SSH
  2) Exec (local)

Select number: 1

Vagrant instance y/n: y
Auto-configure Vagrant from Vagrantfile? y/n: y
/home/392/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/serverspec-2.8.1/lib/serverspec/setup.rb:209:in `find_vagrantfile': uninitialized constant Serverspec::Setup::Pathname (NameError)
        from /home/392/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/serverspec-2.8.1/lib/serverspec/setup.rb:217:in `auto_vagrant_configuration'
        from /home/392/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/serverspec-2.8.1/lib/serverspec/setup.rb:24:in `run'
        from /home/392/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/serverspec-2.8.1/bin/serverspec-init:7:in `<top (required)>'
        from /home/392/.rbenv/versions/2.1.3/bin/serverspec-init:23:in `load'
        from /home/392/.rbenv/versions/2.1.3/bin/serverspec-init:23:in `<main>'
```