### PR TITLE
Add tests for checking if a ruby is installed by RVM

### DIFF
--- a/spec/type/base/package_spec.rb
+++ b/spec/type/base/package_spec.rb
@@ -10,6 +10,14 @@ describe package('jekyll') do
   it { should be_installed.by(:gem).with_version('1.1.1') }
 end
 
+describe package('ruby') do
+  it { should be_installed.by(:rvm) }
+end
+
+describe package('ruby') do
+  it { should be_installed.by(:rvm).with_version('2.2.0') }
+end
+
 describe package('bower') do
   it { should be_installed.by(:npm) }
 end


### PR DESCRIPTION
This pull request just adds a couple tests for checking if a ruby is installed by RVM.

This depends on [the pull request I just opened for serverspec/specinfra](https://github.com/serverspec/specinfra/pull/318), and the CI build check will fail unless that gets merged in.

As the "files changed" section shows, you can use it like this:
```
describe package('ruby') do
  it { should be_installed.by('rvm').with_version('2.2.0') }
end
```