### PR TITLE
Test linux bond member association

### DIFF
--- a/lib/serverspec/helper/type.rb
+++ b/lib/serverspec/helper/type.rb
@@ -2,7 +2,7 @@ module Serverspec
   module Helper
     module Type
       types = %w(
-        base bridge cgroup command cron default_gateway file fstab group host
+        base bridge bond cgroup command cron default_gateway file fstab group host
         iis_website iis_app_pool interface ipfilter ipnat iptables
         ip6tables kernel_module linux_kernel_parameter lxc mail_alias
         package php_config port ppa process routing_table selinux

--- a/lib/serverspec/type/bond.rb
+++ b/lib/serverspec/type/bond.rb
@@ -1,0 +1,11 @@
+module Serverspec::Type
+  class Bond < Base
+    def exists?
+      @runner.check_bridge_exists(@name)
+    end
+
+    def has_interface?(interface)
+      @runner.check_bond_has_interface(@name, interface)
+    end
+  end
+end

--- a/lib/serverspec/type/bond.rb
+++ b/lib/serverspec/type/bond.rb
@@ -1,7 +1,7 @@
 module Serverspec::Type
   class Bond < Base
     def exists?
-      @runner.check_bridge_exists(@name)
+      @runner.check_bond_exists(@name)
     end
 
     def has_interface?(interface)

--- a/spec/type/linux/bond_spec.rb
+++ b/spec/type/linux/bond_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+set :os, :family => 'linux'
+
+describe bond('bond0') do
+  it { should exist }
+end
+
+describe bond('bond0') do
+  let(:stdout) { 'eth0' }
+  it { should have_interface 'eth0' }
+end


### PR DESCRIPTION
Relates to [specinfra PR #323](https://github.com/serverspec/specinfra/pull/3230). Adds support for testing linux bond member presence. These patches does not verify that bond member is working, just that the physical link is part of the bond.