### PR TITLE
Fixed default target of systemctl on `enabled?`

### DIFF
--- a/lib/serverspec/matcher/be_enabled.rb
+++ b/lib/serverspec/matcher/be_enabled.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define :be_enabled do
   match do |subject|
     if subject.class.name == 'Serverspec::Type::Service'
-      subject.enabled?(@level || 3)
+      subject.enabled?(@level)
     else
       subject.enabled?
     end

--- a/lib/serverspec/type/service.rb
+++ b/lib/serverspec/type/service.rb
@@ -1,7 +1,11 @@
 module Serverspec::Type
   class Service < Base
-    def enabled?(level=3)
-      @runner.check_service_is_enabled(@name, level)
+    def enabled?(level)
+      if level
+        @runner.check_service_is_enabled(@name, level)
+      else
+        @runner.check_service_is_enabled(@name)
+      end
     end
 
     def installed?(name, version)


### PR DESCRIPTION
Following specs will failed on my environment (Arch Linux), which uses systemd.

```
describe service('mysqld') do
  it { should be_enabled }
end
```

```
Failure/Error: it { should be_enabled }
  expected Service "mysqld" to be enabled
  /bin/sh -c systemctl\ --plain\ list-dependencies\ runlevel3.target\ \|\ grep\ \'\\\(\^\\\|\ \\\)mysqld.service\$\'
```

An systemd uses target instead of runlevels. The default level passed in `check_service_is_enabled` is tailored to the each environment in Specinfra.