### PR TITLE
Fix generated Rakefile to avoid circular dependencies

### DIFF
--- a/lib/serverspec/setup.rb
+++ b/lib/serverspec/setup.rb
@@ -178,17 +178,20 @@ namespace :spec do
   targets = []
   Dir.glob('./spec/*').each do |dir|
     next unless File.directory?(dir)
-    targets << File.basename(dir)
+    target = File.basename(dir)
+    target = "_#{target}" if target == "default"
+    targets << target
   end
 
   task :all     => targets
   task :default => :all
 
   targets.each do |target|
-    desc "Run serverspec tests to #{target}"
+    original_target = target == "_default" ? target[1..-1] : target
+    desc "Run serverspec tests to #{original_target}"
     RSpec::Core::RakeTask.new(target.to_sym) do |t|
-      ENV['TARGET_HOST'] = target
-      t.pattern = "spec/#{target}/*_spec.rb"
+      ENV['TARGET_HOST'] = original_target
+      t.pattern = "spec/#{original_target}/*_spec.rb"
     end
   end
 end


### PR DESCRIPTION
When the target host is 'default', 'default' task will be triggered. However, 'default' task depends on all tasks, then the circular dependency will be occured.