### PR TITLE
add 'its(:property)' syntax for zfs resource type

### DIFF
--- a/lib/serverspec/type/zfs.rb
+++ b/lib/serverspec/type/zfs.rb
@@ -11,5 +11,19 @@ module Serverspec::Type
     def to_s
       'ZFS'
     end
+
+    def property
+      get_property if @property.nil?
+      @property
+    end
+
+    private
+    def get_property
+      @property = Hash.new
+      @runner.get_zfs_property(@name).stdout.split(/\n/).each do |line|
+        property, value = line.split(/\s+/)
+        @property[property] = value
+      end
+    end
   end
 end


### PR DESCRIPTION
Add 'its(:property)' syntax for zfs resource type like below.

```
describe zfs('rpool') do
  its(:property) { should include( 'mountpoint' => '/rpool', 'atime' => 'on' ) }
end
```

This pull request requires serverspec/specinfra#349
