### PR TITLE
add 'its(:property)' syntax to test property of Solaris service

### DIFF
--- a/lib/serverspec/type/service.rb
+++ b/lib/serverspec/type/service.rb
@@ -33,5 +33,20 @@ module Serverspec::Type
     def has_property?(property)
       @runner.check_service_has_property(@name, property)
     end
+
+    def property
+      get_property if @property.nil?
+      @property
+    end
+
+    private
+    def get_property
+      @property = {}
+      props = @runner.get_service_property(@name).stdout
+      props.split(/\n/).each do |line|
+        property, _type, *value = line.split(/\s+/)
+        @property[property] = value.join(' ')
+      end
+    end
   end
 end


### PR DESCRIPTION
Add 'its(:property)' syntax to test property of Solaris service like below.


```ruby
describe service('apache22') do
  its(:property) { should include('httpd/enable_64bit' => 'true', 'httpd/server_type' => 'worker' ) }
end
```

This pull request requires serverspec/specinfra#352

