### PR TITLE
Integrate selinux file label

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -113,5 +113,9 @@ module Serverspec::Type
     def size
       @runner.get_file_size(@name).stdout.strip.to_i
     end
+
+    def selinux_label
+      @runner.get_selinux_label(@name).stdout.strip.to_i
+    end
   end
 end

--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -115,7 +115,7 @@ module Serverspec::Type
     end
 
     def selinux_label
-      @runner.get_selinux_label(@name).stdout.strip.to_i
+      @runner.get_file_selinuxlabel(@name).stdout.strip
     end
   end
 end

--- a/spec/type/linux/file_spec.rb
+++ b/spec/type/linux/file_spec.rb
@@ -18,3 +18,10 @@ end
 describe file('/tmp') do
   it { should be_immutable }
 end
+
+describe file('/tmp') do
+  let(:exit_status) { 0 }
+  let(:stdout) { 'unconfined_u:unconfined_r:unconfined_t:s0' }
+  its(:selinux_label) { should eq 'unconfined_u:unconfined_r:unconfined_t:s0' }
+end
+


### PR DESCRIPTION
add selinux_label method to file resource type. This allows for selinux context/labels to be checked on files (comparable to `ls -Z`)

```
describe file('/usr/bin/docker') do
  its(:selinux_label) { should match /docker_exec_t/ }
end
```