### PR TITLE
Contain matcher for command outputs

### DIFF
--- a/lib/serverspec/matcher/contain.rb
+++ b/lib/serverspec/matcher/contain.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define :contain do |pattern|
   match do |resource|
     if resource.is_a?(String)
-      resource.match(Regexp.new([@from, pattern, @to].compact.join.gsub('/', '.*')))
+      resource.match(Regexp.new([@from, pattern, @to].compact.join.gsub('/', '.*'), Regexp::MULTILINE))
     else
       resource.contain(pattern, @from, @to)
     end

--- a/lib/serverspec/matcher/contain.rb
+++ b/lib/serverspec/matcher/contain.rb
@@ -1,6 +1,10 @@
 RSpec::Matchers.define :contain do |pattern|
-  match do |file|
-    file.contain(pattern, @from, @to)
+  match do |resource|
+    if resource.is_a?(String)
+      resource.match(Regexp.new([@from, pattern, @to].compact.join.gsub('/', '.*')))
+    else
+      resource.contain(pattern, @from, @to)
+    end
   end
 
   # for contain(pattern).from(/A/).to(/B/)

--- a/spec/type/base/command_spec.rb
+++ b/spec/type/base/command_spec.rb
@@ -59,4 +59,9 @@ EOF
 
   its(:stdout) { should match /bin/ }
   its(:stdout) { should eq stdout }
+  its(:stdout) { should contain('4260') }
+  its(:stdout) { should contain('4260').from('bin').to('home') }
+  its(:stdout) { should contain('4260').after('bin') }
+  its(:stdout) { should contain('4260').before('home') }
+  its(:stdout) { should_not contain('4260').before('bin') }
 end


### PR DESCRIPTION
should contain をcommandのstdout,erroutでも書けるようにしました。
matchでも同じことはできますが、見た目で分かりやすく書けるかと思います。

specから抜粋します。

```
...
  its(:stdout) { should contain('4260') }
  its(:stdout) { should contain('4260').from('bin').to('home') }
  its(:stdout) { should contain('4260').after('bin') }
  its(:stdout) { should contain('4260').before('home') }
  its(:stdout) { should_not contain('4260').before('bin') }
...
```