### PR TITLE
Adds portbinding check

### DIFF
--- a/lib/serverspec/type/docker_container.rb
+++ b/lib/serverspec/type/docker_container.rb
@@ -7,5 +7,12 @@ module Serverspec::Type
     def has_volume?(container_path, host_path)
       inspection['Volumes'][container_path] == host_path
     end
+
+    def has_bindports?(container_port, host_port)
+      inspection['HostConfig']['PortBindings'][container_port].each do |port|
+        return true if port['HostPort'] == host_port
+      end
+      false
+    end
   end
 end

--- a/spec/type/linux/docker_container_spec.rb
+++ b/spec/type/linux/docker_container_spec.rb
@@ -14,6 +14,7 @@ describe docker_container('c1') do
   it { should have_volume('/tmp', '/data') }
   its(:inspection) { should include 'Driver' => 'aufs' }
   its(['Config.Cmd']) { should include '/bin/sh' }
+  it { should have_bindports('8080/tcp', '8080') }
 end
 
 def inspect_container
@@ -62,7 +63,13 @@ def inspect_container
         "Links": null,
         "LxcConf": [],
         "NetworkMode": "bridge",
-        "PortBindings": {},
+        "PortBindings": {
+          "8080/tcp": [
+            {
+              "HostPort": "8080"
+            }
+          ]
+        },
         "Privileged": false,
         "PublishAllPorts": false,
         "VolumesFrom": null


### PR DESCRIPTION
Allows de docker_container resource to check for bindports like so:

```ruby
describe docker_container('test-001') do
  it { should have_bindports('8080/tcp', '8080') }
end
```

Which is a lot more readable than:

```ruby
describe command("docker inspect test-001 | grep -A 4 'PortBindings'") do
  its(:stdout) { should match(/"8080\/tcp":/) }
  its(:stdout) { should match(/"HostPort": "8080"/) }
end
```