### PR TITLE
add File#exists?

### DIFF
--- a/lib/serverspec/type/file.rb
+++ b/lib/serverspec/type/file.rb
@@ -86,6 +86,10 @@ module Serverspec::Type
       @runner.check_file_is_immutable(@name)
     end
 
+    def exists?
+      @runner.check_file_exists(@name)
+    end
+
     def md5sum
       @runner.get_file_md5sum(@name).stdout.strip
     end

--- a/spec/type/base/file_spec.rb
+++ b/spec/type/base/file_spec.rb
@@ -22,6 +22,10 @@ describe file('/bin/sh') do
   it { should be_symlink }
 end
 
+describe file('/bin/sh') do
+  it { should exist }
+end
+
 describe file('/etc/ssh/sshd_config') do
   it { should contain 'This is the sshd server system-wide configuration file' }
 end


### PR DESCRIPTION
When doing negative testing, I.e., asserting that 'this' path should not exist, it would be more concise to be able to express this in serverspec as:

```
describe File('/does_not_exist') do
  it { should_not exist }
end
```