### PR TITLE
Integration test for winrm with appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,57 @@
+version: "{build}"
+
+os: Windows Server 2012
+platform:
+  - x64
+
+environment:
+  bundle_gemfile: integration-test/Gemfile.winrm
+  bundler_url: https://rubygems.org/downloads/bundler-1.9.9.gem
+
+  matrix:
+    - ruby_version: "193"
+    - ruby_version: "200"
+    - ruby_version: "21"
+    - ruby_version: "22"
+
+matrix:
+  allow_failures:
+    - ruby_version: "22" # waiting for net-ssh update
+
+clone_depth: 5
+
+cache:
+  - C:\Ruby193\lib\ruby\gems\1.9.1
+  - C:\Ruby193\bin
+  - C:\Ruby200\lib\ruby\gems\2.0.0
+  - C:\Ruby200\bin
+  - C:\Ruby21\lib\ruby\gems\2.1.0
+  - C:\Ruby21\bin
+  - C:\Ruby22\lib\ruby\gems\2.2.0
+  - C:\Ruby22\bin
+
+install:
+  - git submodule update --init --recursive
+  - ps: Enable-PSRemoting -Force
+  - ps: Set-ExecutionPolicy RemoteSigned
+  - winrm quickconfig -q
+  - winrm set winrm/config/client @{TrustedHosts="*"}
+  - winrm set winrm/config/client/auth @{Basic="true"}
+  - winrm set winrm/config/service/auth @{Basic="true"}
+  - winrm set winrm/config/service @{AllowUnencrypted="true"}
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - echo %PATH%
+  - ruby --version
+  - gem --version
+  - appveyor DownloadFile -Url %bundler_url% -FileName bundler.gem
+  - gem install --local bundler.gem --no-ri --no-rdoc ## appveyor often stops `gem install bundler`..?
+
+build_script:
+  - ruby -rfileutils -e 'FileUtils.rm_r(File.join(Gem.dir, "cache", "bundler")) if Dir.exists?(File.join(Gem.dir, "cache", "bundler"))'
+  - bundle install --jobs 3 --retry 3
+  - net user
+  - net localgroup
+
+test_script:
+  - net user appveyor %WINDOWS_PASSWORD% # set by webui
+  - bundle exec rspec -fd --backtrace -r .\integration-test\winrm\spec_helper.rb .\integration-test\winrm


### PR DESCRIPTION
AppveyorでリモートWindowsに対する結合テストを実施します。

https://ci.appveyor.com/project/serverspec-windows-integration-test/serverspec

以下をとりあえずAppveyor側にて設定しています。

- appveyor.ymlのないブランチは無視
- ENV: WINDOWS_PASSWORD
- serverspec/owners に編集権Grant ？ (ここ調整の余地あり)
- Windows x Ruby2.2はnet-sshの問題があるようなのでFail無視

結構時間がかかるので、Windows対応が心配になるPRの時だけ待つ感じで。