### PR TITLE
Fix x509 date parser

### DIFF
--- a/lib/serverspec/type/x509_certificate.rb
+++ b/lib/serverspec/type/x509_certificate.rb
@@ -68,7 +68,8 @@ module Serverspec::Type
     def parse_dates_str_to_map(dates_str)
       dates_str.split("\n").inject({}) do |res,line|
         kv_arr = line.split '='
-        res.merge({ kv_arr[0].to_sym => Time.parse(kv_arr[1] || '') })
+        time = Time.strptime(kv_arr[1],'%b %e %T %Y %Z') rescue Time.parse(kv_arr[1] || '')
+        res.merge({ kv_arr[0].to_sym => time })
       end
     end
   end


### PR DESCRIPTION
Time.parse does not pick up timezone data in the openssl date string.
Instead of that, use strftime with a valid time parser. Just in case the
parser fails, it falls back to the Time.parse.