### PR TITLE
Add table method to cron type

### DIFF
--- a/lib/serverspec/type/cron.rb
+++ b/lib/serverspec/type/cron.rb
@@ -4,6 +4,10 @@ module Serverspec::Type
       @runner.check_cron_has_entry(user, entry)
     end
 
+    def table
+      @runner.get_cron_table.stdout
+    end
+
     def to_s
       'Cron'
     end

--- a/serverspec.gemspec
+++ b/serverspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rspec", "~> 3.0"
   spec.add_runtime_dependency "rspec-its"
   spec.add_runtime_dependency "multi_json"
-  spec.add_runtime_dependency "specinfra", "~> 2.35"
+  spec.add_runtime_dependency "specinfra", "~> 2.38"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1.1"
 end


### PR DESCRIPTION
You can write cron tests like this with this PR.

```ruby
describe cron do
  its(:table) { should match %r{^\* \* \* \* \* ls /tmp$} }
end

describe cron do
  let(:sudo_options) { '-u daemon' }
  its(:table) { should match /^\* \* \* \* \* command by daemon user$/ }
end
```